### PR TITLE
bugs/terra-testing

### DIFF
--- a/tests/unit/test_my_annotator.py
+++ b/tests/unit/test_my_annotator.py
@@ -218,8 +218,6 @@ def test_cache(my_translator):
 
     assert elapsed_time2 < (elapsed_time / 4), f"Cache should make things significantly faster first {elapsed_time} second {elapsed_time2}."
 
-    assert pathlib.Path(pathlib.Path.home() / '.cache' / 'allele_translator').exists(), "Cache directory not found."
-
 
 @pytest.fixture()
 def num_threads():

--- a/vrs_anvil/__init__.py
+++ b/vrs_anvil/__init__.py
@@ -172,6 +172,7 @@ def generate_gnomad_ids(vcf_line, compute_for_ref: bool = True) -> list[str]:
                 continue
             else:
                 gnomad_ids.append(f"{gnomad_loc}-{reference_allele}-{alt}")
+                break
 
     return gnomad_ids
 

--- a/vrs_anvil/__init__.py
+++ b/vrs_anvil/__init__.py
@@ -14,7 +14,7 @@ from ga4gh.vrs.extras.translator import AlleleTranslator
 from glom import glom
 from pydantic import BaseModel, model_validator
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger("vrs_anvil")
 LOGGED_ALREADY = set()
 
 manifest: 'Manifest' = None
@@ -127,7 +127,7 @@ class ThreadedTranslator(BaseModel):
             except Exception as e:
                 result_dict['error'] = str(e)
                 result_dict['stack_trace'] = traceback.format_exc()
-                _logger.debug(result_dict)
+                _logger.warning(result_dict)
             results_queue.put(result_dict)
 
         def _ensure_tuple(item):

--- a/vrs_anvil/__init__.py
+++ b/vrs_anvil/__init__.py
@@ -126,6 +126,7 @@ class ThreadedTranslator(BaseModel):
             except Exception as e:
                 result_dict['error'] = str(e)
                 result_dict['stack_trace'] = traceback.format_exc()
+                _logger.debug(result_dict)
             results_queue.put(result_dict)
 
         def _ensure_tuple(item):
@@ -238,6 +239,7 @@ class Manifest(BaseModel):
 
     vcf_files: list[str]
     """The local file paths or URLs to vcf files to be processed"""
+    # TODO - 2x check why local files need to be absolute paths
 
     work_directory: str = "work/"
     """The directory to store intermediate files"""

--- a/vrs_anvil/__init__.py
+++ b/vrs_anvil/__init__.py
@@ -170,7 +170,7 @@ def generate_gnomad_ids(vcf_line, compute_for_ref: bool = True) -> list[str]:
                     LOGGED_ALREADY.add(_)
                     _logger.error(_)
                 continue
-        gnomad_ids.append(f"{gnomad_loc}-{reference_allele}-{alt}")
+            gnomad_ids.append(f"{gnomad_loc}-{reference_allele}-{alt}")
 
     return gnomad_ids
 

--- a/vrs_anvil/__init__.py
+++ b/vrs_anvil/__init__.py
@@ -163,16 +163,17 @@ def generate_gnomad_ids(vcf_line, compute_for_ref: bool = True) -> list[str]:
         alt = alt.strip()
         # TODO - Should we be raising a ValueError hear and let the caller do the logging?
         invalid_alts = ['<INS>', '<DEL>', '<DUP>', '<INV>', '<CNV>', '<DUP:TANDEM>', '<DUP:INT>', '<DUP:EXT>', '*']
+        is_valid = True
         for invalid_alt in invalid_alts:
             if invalid_alt in alt:
+                is_valid = False
                 _ = f"Invalid allele found: {alt}"
                 if _ not in LOGGED_ALREADY:
                     LOGGED_ALREADY.add(_)
                     _logger.error(_)
                 break
-            else:
-                gnomad_ids.append(f"{gnomad_loc}-{reference_allele}-{alt}")
-                break
+        if is_valid:
+            gnomad_ids.append(f"{gnomad_loc}-{reference_allele}-{alt}")
 
     return gnomad_ids
 

--- a/vrs_anvil/__init__.py
+++ b/vrs_anvil/__init__.py
@@ -18,6 +18,11 @@ _logger = logging.getLogger(__name__)
 
 manifest: 'Manifest' = None
 
+# TODO - read from manifest
+gigabytes = 20
+bytes_in_a_gigabyte = 1024 ** 3  # 1 gigabyte = 1024^3 bytes
+cache_size_limit = gigabytes * bytes_in_a_gigabyte
+
 
 def seqrepo_dir():
     """Return the seqrepo directory."""
@@ -42,7 +47,7 @@ class CachingAlleleTranslator(AlleleTranslator):
     def __init__(self, data_proxy: SeqRepoDataProxy, normalize: bool = False):
         super().__init__(data_proxy)
         self.normalize = normalize
-        self._cache = Cache(directory=cache_directory('allele_translator'))
+        self._cache = Cache(directory=cache_directory('allele_translator'), size_limit=cache_size_limit)
 
     def translate_from(self, var, fmt=None, **kwargs):
         """Check and update cache"""

--- a/vrs_anvil/__init__.py
+++ b/vrs_anvil/__init__.py
@@ -170,7 +170,8 @@ def generate_gnomad_ids(vcf_line, compute_for_ref: bool = True) -> list[str]:
                     LOGGED_ALREADY.add(_)
                     _logger.error(_)
                 continue
-            gnomad_ids.append(f"{gnomad_loc}-{reference_allele}-{alt}")
+            else:
+                gnomad_ids.append(f"{gnomad_loc}-{reference_allele}-{alt}")
 
     return gnomad_ids
 

--- a/vrs_anvil/__init__.py
+++ b/vrs_anvil/__init__.py
@@ -169,7 +169,7 @@ def generate_gnomad_ids(vcf_line, compute_for_ref: bool = True) -> list[str]:
                 if _ not in LOGGED_ALREADY:
                     LOGGED_ALREADY.add(_)
                     _logger.error(_)
-                continue
+                break
             else:
                 gnomad_ids.append(f"{gnomad_loc}-{reference_allele}-{alt}")
                 break

--- a/vrs_anvil/__init__.py
+++ b/vrs_anvil/__init__.py
@@ -262,6 +262,9 @@ class Manifest(BaseModel):
     cache_enabled: Optional[bool] = True
     """Cache results"""
 
+    compute_for_ref: Optional[bool] = False
+    """Compute reference allele"""
+
     @model_validator(mode='after')
     def check_paths(self) -> 'Manifest':
         """Post init method to set the cache directory."""

--- a/vrs_anvil/__init__.py
+++ b/vrs_anvil/__init__.py
@@ -162,7 +162,9 @@ def generate_gnomad_ids(vcf_line, compute_for_ref: bool = True) -> list[str]:
     for alt in alternate_allele.split(","):
         alt = alt.strip()
         # TODO - Should we be raising a ValueError hear and let the caller do the logging?
-        invalid_alts = ['<INS>', '<DEL>', '<DUP>', '<INV>', '<CNV>', '<DUP:TANDEM>', '<DUP:INT>', '<DUP:EXT>', '*']
+        # TODO - Should this be a config in the manifest?
+        # ['<INS>', '<DEL>', '<DUP>', '<INV>', '<CNV>', '<DUP:TANDEM>', '<DUP:INT>', '<DUP:EXT>', '*']
+        invalid_alts = ['INS', 'DEL', 'DUP', 'INV', 'CNV', 'TANDEM', 'INT', 'EXT', '*']
         is_valid = True
         for invalid_alt in invalid_alts:
             if invalid_alt in alt:

--- a/vrs_anvil/__init__.py
+++ b/vrs_anvil/__init__.py
@@ -268,6 +268,9 @@ class Manifest(BaseModel):
     compute_for_ref: Optional[bool] = False
     """Compute reference allele"""
 
+    estimated_vcf_lines: Optional[int] = 4000000
+    """How many lines per vcf file?  Used for progress bar"""
+
     @model_validator(mode='after')
     def check_paths(self) -> 'Manifest':
         """Post init method to set the cache directory."""

--- a/vrs_anvil/annotator.py
+++ b/vrs_anvil/annotator.py
@@ -1,6 +1,7 @@
 import pathlib
 import time
 from collections import defaultdict
+from datetime import datetime
 from typing import Generator
 
 import yaml
@@ -105,7 +106,9 @@ def annotate_all(manifest: Manifest, max_errors: int):
     metrics["total"]["successes"] = sum([metrics[key].get("successes", 0) for key in metrics.keys() if key != "total"])
     metrics["total"]["errors"] = sum([sum(metrics[key]["errors"].values()) for key in metrics.keys() if key != "total"])
 
-    metrics_file = pathlib.Path(manifest.state_directory) / "metrics.yaml"
+    # Append timestamp to filename
+    timestamp_str = datetime.now().strftime("%Y%m%d_%H%M%S")
+    metrics_file = pathlib.Path(manifest.state_directory) / f"metrics_{timestamp_str}.yaml"
     with open(metrics_file, "w") as f:
         # clean up the recursive dict into a plain old dict so that it serialized to yaml neatly
         for k, v in metrics.items():

--- a/vrs_anvil/annotator.py
+++ b/vrs_anvil/annotator.py
@@ -72,8 +72,8 @@ def _vrs_generator(manifest: Manifest) -> Generator[dict, None, None]:
         yield result
 
 
-def annotate_all(manifest: Manifest, max_errors: int):
-    """Annotate all the files in the manifest."""
+def annotate_all(manifest: Manifest, max_errors: int) -> pathlib.Path:
+    """Annotate all the files in the manifest. Return a file with metrics."""
 
     # set the manifest in a well known place, TODO: is this really necessary
     vrs_anvil.manifest = manifest
@@ -116,3 +116,4 @@ def annotate_all(manifest: Manifest, max_errors: int):
             if 'errors' in metrics[k] and k != 'total':
                 metrics[k]['errors'] = dict(metrics[k]['errors'])
         yaml.dump(dict(metrics), f)
+    return metrics_file

--- a/vrs_anvil/annotator.py
+++ b/vrs_anvil/annotator.py
@@ -67,8 +67,10 @@ def _vcf_generator(manifest: Manifest) -> Generator[tuple, None, None]:
 def _vrs_generator(manifest: Manifest) -> Generator[dict, None, None]:
     """Return a generator for the VRS ids."""
     tlr = ThreadedTranslator(normalize=manifest.normalize)
-    for result in tlr.threaded_translate_from(generator=tqdm(_vcf_generator(manifest), total=4000000),
-                                              num_threads=manifest.num_threads):
+    for result in tlr.threaded_translate_from(
+        generator=tqdm(_vcf_generator(manifest), total=manifest.estimated_vcf_lines),
+        num_threads=manifest.num_threads
+    ):
         yield result
 
 

--- a/vrs_anvil/annotator.py
+++ b/vrs_anvil/annotator.py
@@ -51,7 +51,7 @@ def _vcf_generator(manifest: Manifest) -> Generator[tuple, None, None]:
                 line_number += 1
                 if line.startswith("#"):
                     continue
-                for gnomad_id in generate_gnomad_ids(line):
+                for gnomad_id in generate_gnomad_ids(line, compute_for_ref=manifest.compute_for_ref):
                     yield {"fmt": "gnomad", "var": gnomad_id}, work_file, line_number
                 if manifest.limit and line_number > manifest.limit:
                     _logger.info(f"Limit of {manifest.limit} reached, stopping")

--- a/vrs_anvil/annotator.py
+++ b/vrs_anvil/annotator.py
@@ -11,6 +11,9 @@ import vrs_anvil
 from vrs_anvil import Manifest, ThreadedTranslator, generate_gnomad_ids
 from vrs_anvil.collector import collect_manifest_urls
 import gzip
+import logging
+
+_logger = logging.getLogger(__name__)
 
 
 def recursive_defaultdict():
@@ -49,6 +52,9 @@ def _vcf_generator(manifest: Manifest) -> Generator[tuple, None, None]:
                     continue
                 for gnomad_id in generate_gnomad_ids(line):
                     yield {"fmt": "gnomad", "var": gnomad_id}, work_file, line_number
+                if manifest.limit and line_number > manifest.limit:
+                    _logger.info(f"Limit of {manifest.limit} reached, stopping")
+                    break
 
             metrics[key]["status"] = 'finished'
             metrics[key]["end_time"] = time.time()

--- a/vrs_anvil/annotator.py
+++ b/vrs_anvil/annotator.py
@@ -14,7 +14,7 @@ from vrs_anvil.collector import collect_manifest_urls
 import gzip
 import logging
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger("vrs_anvil.annotator")
 
 
 def recursive_defaultdict():

--- a/vrs_anvil/cli.py
+++ b/vrs_anvil/cli.py
@@ -27,12 +27,9 @@ def cli(ctx, verbose: bool, manifest: str, max_errors: int):
     _log_level = logging.INFO
     if verbose:
         _log_level = logging.DEBUG
-
     try:
         with open(manifest, 'r') as stream:
             manifest = Manifest.parse_obj(yaml.safe_load(stream))
-            # basicConfig call removed, which prevents the default configuration that logs to the console.
-            # logging.basicConfig(level=_log_level, format=log_format)
 
             # Create a rotating file handler with a max size of 10MB and keep 3 backup files
             log_path = pathlib.Path(manifest.state_directory) / "vrs_anvil.log"
@@ -42,8 +39,11 @@ def cli(ctx, verbose: bool, manifest: str, max_errors: int):
             file_handler.setFormatter(logging.Formatter(log_format))
 
             # Add the file handler to the logger
-            logger = logging.getLogger()
-            logger.addHandler(file_handler)
+            # logger = logging.getLogger()
+            # logger.addHandler(file_handler)
+            # basicConfig call removed, which prevents the default configuration that logs to the console.
+            logging.basicConfig(level=_log_level, format=log_format, handlers=[file_handler])
+
             click.secho(f"🪵  Logging to {log_path}, level {logging.getLevelName(_log_level)}", fg='yellow')
 
             ctx.ensure_object(dict)

--- a/vrs_anvil/cli.py
+++ b/vrs_anvil/cli.py
@@ -17,13 +17,13 @@ _logger = logging.getLogger(__name__)
 
 @click.group(invoke_without_command=True)
 @click.version_option(package_name='vrs_anvil')
-@click.option('--manifest', type=click.Path(exists=True), default='manifest.yaml', help='Path to manifest file.')
+@click.option('--manifest', type=click.Path(exists=False), default='manifest.yaml', help='Path to manifest file.')
 @click.option('--verbose', default=False, help='Log more information', is_flag=True)
 @click.option('--max_errors', default=10, help='Number of acceptable errors.')
 @click.pass_context
 def cli(ctx, verbose: bool, manifest: str, max_errors: int):
     """GA4GH GKS utility for AnVIL."""
-    
+
     _log_level = logging.INFO
     if verbose:
         _log_level = logging.DEBUG
@@ -31,34 +31,32 @@ def cli(ctx, verbose: bool, manifest: str, max_errors: int):
     try:
         with open(manifest, 'r') as stream:
             manifest = Manifest.parse_obj(yaml.safe_load(stream))
+            # basicConfig call removed, which prevents the default configuration that logs to the console.
+            # logging.basicConfig(level=_log_level, format=log_format)
+
+            # Create a rotating file handler with a max size of 10MB and keep 3 backup files
+            log_path = pathlib.Path(manifest.state_directory) / "vrs_anvil.log"
+            file_handler = RotatingFileHandler(
+                    log_path, maxBytes=10 * 1024 * 1024, backupCount=3)
+            file_handler.setLevel(_log_level)
+            file_handler.setFormatter(logging.Formatter(log_format))
+
+            # Add the file handler to the logger
+            logger = logging.getLogger()
+            logger.addHandler(file_handler)
+            click.secho(f"🪵  Logging to {log_path}, level {logging.getLevelName(_log_level)}", fg='yellow')
+
+            ctx.ensure_object(dict)
+            ctx.obj['manifest'] = manifest
+            ctx.obj['verbose'] = verbose
+            ctx.obj['max_errors'] = max_errors
+
+            if verbose:
+                click.secho(f"📢 {manifest}", fg='green')
+
     except Exception as exc:
-        click.secho(f"Error in initializing: {exc}", fg='red')
-        _logger.exception(exc)
-        exit(1)
-
-    #  basicConfig call removed, which prevents the default configuration that logs to the console. 
-    # logging.basicConfig(level=_log_level, format=log_format)
-
-    # Create a rotating file handler with a max size of 10MB and keep 3 backup files
-    log_path = pathlib.Path(manifest.state_directory) / "vrs_anvil.log"
-    file_handler = RotatingFileHandler(
-            log_path, maxBytes=10 * 1024 * 1024, backupCount=3)
-    file_handler.setFormatter(logging.Formatter(log_format))
-
-    # Add the file handler to the logger
-    logger = logging.getLogger()
-    logger.addHandler(file_handler)
-    click.secho(f"🪵  Logging to {log_path}", fg='yellow')
-
-    if not ctx.invoked_subcommand:
-        click.secho(manifest, fg='green')
-        # TODO - what purpose does this serve?
-        click.secho('No subcommand invoked', fg='yellow')
-
-    ctx.ensure_object(dict)
-    ctx.obj['manifest'] = manifest
-    ctx.obj['verbose'] = verbose
-    ctx.obj['max_errors'] = max_errors
+        click.secho(f"{exc}", fg='yellow')
+        ctx.ensure_object(dict)
 
 
 @cli.command('annotate')
@@ -67,13 +65,14 @@ def annotate_cli(ctx):
     """Read manifest file, annotate variants, all parameters controlled by manifest.yaml."""
 
     try:
+        assert 'manifest' in ctx.obj, "Manifest not found."
         manifest = ctx.obj['manifest']
         _logger.debug(f"Manifest: {ctx.obj['manifest']}")
         click.secho("🚧  annotating variants", fg='yellow')
         annotate_all(manifest, max_errors=ctx.obj['max_errors'])
         click.secho(f"🥳  metrics available in {manifest.state_directory}", fg='green')
     except Exception as exc:
-        click.secho(f"Error in processing: {exc}", fg='red')
+        click.secho(f"{exc}", fg='red')
         _logger.exception(exc)
 
 

--- a/vrs_anvil/cli.py
+++ b/vrs_anvil/cli.py
@@ -9,10 +9,9 @@ from logging.handlers import RotatingFileHandler
 import pathlib
 
 # Set up logging
-log_format = "%(asctime)s %(filename)s [%(levelname)s] %(message)s"
+log_format = "%(asctime)s %(name)s [%(levelname)s] %(message)s"
 
-
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger("vrs_anvil.cli")
 
 
 @click.group(invoke_without_command=True)
@@ -39,7 +38,6 @@ def cli(ctx, verbose: bool, manifest: str, max_errors: int):
             file_handler.setFormatter(logging.Formatter(log_format))
 
             # Add the file handler to the logger
-            # logger = logging.getLogger()
             # logger.addHandler(file_handler)
             # basicConfig call removed, which prevents the default configuration that logs to the console.
             logging.basicConfig(level=_log_level, format=log_format, handlers=[file_handler])

--- a/vrs_anvil/cli.py
+++ b/vrs_anvil/cli.py
@@ -52,7 +52,7 @@ def cli(ctx, verbose: bool, manifest: str, max_errors: int):
             ctx.obj['max_errors'] = max_errors
 
             if verbose:
-                click.secho(f"📢 {manifest}", fg='green')
+                click.secho(f"📢  {manifest}", fg='green')
 
     except Exception as exc:
         click.secho(f"{exc}", fg='yellow')
@@ -69,8 +69,8 @@ def annotate_cli(ctx):
         manifest = ctx.obj['manifest']
         _logger.debug(f"Manifest: {ctx.obj['manifest']}")
         click.secho("🚧  annotating variants", fg='yellow')
-        annotate_all(manifest, max_errors=ctx.obj['max_errors'])
-        click.secho(f"🥳  metrics available in {manifest.state_directory}", fg='green')
+        metrics_file = annotate_all(manifest, max_errors=ctx.obj['max_errors'])
+        click.secho(f"🥳  metrics available in {metrics_file}", fg='green')
     except Exception as exc:
         click.secho(f"{exc}", fg='red')
         _logger.exception(exc)

--- a/vrs_anvil/collector.py
+++ b/vrs_anvil/collector.py
@@ -89,4 +89,3 @@ def collect_manifest_urls(manifest: Manifest) -> Generator[str, None, None]:
         # Yield results as they become available
         for _ in as_completed(futures):
             yield _.result()
-

--- a/vrs_anvil/collector.py
+++ b/vrs_anvil/collector.py
@@ -18,7 +18,6 @@ def download_s3_object(bucket_name, object_name, destination_file_name) -> str:
     return destination_file_name
 
 
-# TODO - not tested
 def download_google_blob(bucket_name, source_blob_name, destination_file_name) -> str:
     """Downloads a blob from the bucket."""
     if os.path.exists(destination_file_name):


### PR DESCRIPTION
This PR has several changes based on terra testing:
* fix: cache directory no longer in home
* feature: in collector, use GOOGLE user account, create parent subpath in collector, read from zip file in annotator. FIXED
* progress bars, see https://stackoverflow.com/a/42205097, added estimate count in manifest (4M)
* feature: added cache enable in manifest
* feature: added manifest config to calculate reference allele (false)
* feature: timestamp the metrics file, so they are not overwritten
* feature: invalid alts: logged once as an error, parsables logged as warning #16 
* feature: all logging goes to a rotating disk file in state/vrs_anvil.log

TODO:
* we need to write technote https://github.com/biocommons/biocommons.seqrepo/pull/131 see SEQREPO_FD_CACHE_MAXSIZE, try different values, record performance changes
* warning: logging is naive `--verbose` sets logging to DEBUG - this affects `all` processes. Will slow things down

Results:
* cache write overhead estimated ~10% added manifest.cache_enabled to allow user to toggle cache, added cache size 10GB




