### PR TITLE
feature/making-cache-scalable

### DIFF
--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,20 +1,19 @@
-def validate_threaded_result(result, errors, validate_passthrough=False):
+def validate_threaded_result(result, validate_passthrough=False):
     """Test helper, a utility method to validate threaded lookup result."""
     assert result is not None, "result_dict is None"
     from vrs_anvil.translator import VCFItem
 
     assert isinstance(result, VCFItem), "result_dict is not a dict"
-    allele = result.result
-    if isinstance(allele, dict):
-        _ = allele  # handle dummy results
-    else:
-        _ = allele.model_dump(exclude_none=True)
-    assert _ is not None, "result from allele lookup is missing"
-    if "error" in _:
-        errors.append(_)
-        return
-    for k in ["location", "state", "type"]:
-        assert k in _, f"{k} not in result from allele lookup"
+
+    allele_id = result.result
+    assert isinstance(
+        allele_id, str
+    ), f"translated VRS Allele ID is a {type(allele_id)} not a string"
+    prefix, hash = allele_id.split(".")
+    assert (
+        prefix == "ga4gh:VA" and len(hash) == 32
+    ), "VRS Allele ID format has changed, consult https://vrs.ga4gh.org/en/stable/impl-guide/computed_identifiers.html#identify"
+
     for k in ["file_name", "line_number"]:
         if validate_passthrough:
             assert (

--- a/tests/unit/test_1000g_vcf.py
+++ b/tests/unit/test_1000g_vcf.py
@@ -1,5 +1,3 @@
-import time
-
 from tests.unit import validate_threaded_result
 from vrs_anvil import params_from_vcf
 
@@ -9,18 +7,11 @@ def test_1000g_vcf(translator, thousand_genome_vcf, num_threads):
     tlr = translator
     assert tlr is not None
     c = 0  # count of results
-    start_time = time.time()
-    errors = []
     for result_dict in tlr.translate_from(
         generator=params_from_vcf(thousand_genome_vcf), num_threads=num_threads
     ):
         c += 1
-        validate_threaded_result(result_dict, errors, validate_passthrough=True)
-    end_time = time.time()
+        print(result_dict)
+        validate_threaded_result(result_dict, validate_passthrough=True)
 
-    elapsed_time = end_time - start_time
-
-    print(errors)
-    assert (
-        len(errors) == 0
-    ), f"num_threads {num_threads}, elapsed time: {elapsed_time} seconds, {c} items, {len(errors)} errors {errors}."
+    validate_threaded_result(result_dict)

--- a/tests/unit/test_annotator.py
+++ b/tests/unit/test_annotator.py
@@ -159,13 +159,11 @@ def test_results(caching_translator):
     for variant_type, (input, expected_allele) in inputs_dict.items():
         gnomad_expr = input["gnomad"]
         # allele object validation
-        allele_dict = tlr.translate_from(fmt="gnomad", var=gnomad_expr).model_dump(
-            exclude_none=True
-        )
+        allele_id = tlr.translate_from(fmt="gnomad", var=gnomad_expr)
 
-        assert expected_allele == allele_dict, (
-            f"{variant_type} does not match for {gnomad_expr}: "
-            + f"\nexpected: {expected_allele}\n!==\nactual: {allele_dict}"
+        assert expected_allele["id"] == allele_id, (
+            f"{allele_id} does not match for {gnomad_expr}: "
+            + f"\nexpected: {expected_allele["id"]}"
         )
 
 
@@ -179,16 +177,12 @@ def test_cache(caching_translator):
 
     start_time = time.time()
     for inputs in all_inputs:
-        tlr.translate_from(fmt="gnomad", var=inputs["gnomad"]).model_dump(
-            exclude_none=True
-        )
+        tlr.translate_from(fmt="gnomad", var=inputs["gnomad"])
     noncached_time = time.time() - start_time
 
     start_time = time.time()
     for inputs in all_inputs:
-        tlr.translate_from(fmt="gnomad", var=inputs["gnomad"]).model_dump(
-            exclude_none=True
-        )
+        tlr.translate_from(fmt="gnomad", var=inputs["gnomad"])
     cache_time = time.time() - start_time
 
     assert cache_time < (
@@ -241,18 +235,11 @@ def test_threading(translator, num_threads):
 
     c = 0  # count of results
     _times = 2
-    errors = []
     for result in tlr.translate_from(
         repeat_sequence(parameters, times=_times), num_threads=num_threads
     ):
         c += 1
-        validate_threaded_result(result, errors, validate_passthrough=False)
-    assert c == (
-        _times * len(parameters)
-    ), f"Expected {_times * len(parameters)} results, got {c}."
-    assert (
-        len(errors) == 0
-    ), f"num_threads {num_threads} {c} items {len(errors)} errors {errors}."
+        validate_threaded_result(result, validate_passthrough=False)
 
 
 @pytest.fixture
@@ -289,21 +276,11 @@ def test_gnomad(translator, gnomad_csv, num_threads):
     tlr = translator
     assert tlr is not None
     c = 0  # count of results
-    start_time = time.time()
-    errors = []
     for result_dict in tlr.translate_from(
         generator=gnomad_ids(gnomad_csv), num_threads=num_threads
     ):
         c += 1
-        validate_threaded_result(result_dict, errors, validate_passthrough=False)
-    end_time = time.time()
-
-    elapsed_time = end_time - start_time
-
-    print(errors)
-    assert (
-        len(errors) == 0
-    ), f"num_threads {num_threads} elapsed time: {elapsed_time} seconds {c} items {len(errors)} errors {errors}."
+        validate_threaded_result(result_dict, validate_passthrough=False)
 
 
 def test_gnomad_inline(translator, gnomad_csv, num_threads=1):
@@ -311,18 +288,8 @@ def test_gnomad_inline(translator, gnomad_csv, num_threads=1):
     tlr = translator
     assert tlr is not None
     c = 0  # count of results
-    start_time = time.time()
-    errors = []
     for result_dict in tlr.translate_from(
         generator=gnomad_ids(gnomad_csv), num_threads=num_threads
     ):
         c += 1
-        validate_threaded_result(result_dict, errors, validate_passthrough=False)
-    end_time = time.time()
-
-    elapsed_time = end_time - start_time
-
-    print(errors)
-    assert (
-        len(errors) == 0
-    ), f"num_threads {num_threads} elapsed time: {elapsed_time} seconds {c} items {len(errors)} errors {errors}."
+        validate_threaded_result(result_dict, validate_passthrough=False)

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -53,9 +53,8 @@ def test_threaded_translator(gnomad_csv):
     c = 0
     for _ in results:
         assert isinstance(_, VCFItem), "should get a VRS id"
-        allele = _.result
-        assert allele.id is not None, "allele.id is None"
-        assert "ga4gh:VA." in allele.id, "allele.id is not a VRS id"
+        allele_id = _.result
+        assert allele_id is not None, "allele.id is None"
         c += 1
 
     if limit:

--- a/vrs_anvil/__init__.py
+++ b/vrs_anvil/__init__.py
@@ -8,6 +8,7 @@ import zipfile
 import psutil
 from biocommons.seqrepo import SeqRepo
 from diskcache import Cache
+from ga4gh.vrs import models as VRS
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy
 from ga4gh.vrs.extras.translator import AlleleTranslator
 from pathlib import Path
@@ -73,12 +74,16 @@ class CachingAlleleTranslator(AlleleTranslator):
             if key in self._cache:
                 return self._cache[key]
 
-        val = super().translate_from(var, fmt=fmt, **kwargs)
+        allele = super().translate_from(var, fmt=fmt, **kwargs)
+
+        assert isinstance(
+            allele, VRS.Allele
+        ), f"Allele is not the expected Pydantic Model {type(allele)}: {allele}"
 
         if self._cache is not None:
-            self._cache[key] = val
+            self._cache[key] = allele.id
 
-        return val
+        return allele.id
 
 
 def caching_allele_translator_factory(

--- a/vrs_anvil/annotator.py
+++ b/vrs_anvil/annotator.py
@@ -164,7 +164,7 @@ def annotate_all(
             metrics[file_path][SUCCESSES] += 1
 
             # check metaKB cache, TODO - it would be nice if we had the metakb.study.id and added that to result_dict
-            if any([metakb_proxy.get(_) for _ in allele_id]):
+            if metakb_proxy.get(allele_id):
                 _logger.info(f"VRS id {allele_id} found in metakb. {result}")
 
                 # add vrs_id, allele_dict, actual evidence to this object as well (#3)

--- a/vrs_anvil/annotator.py
+++ b/vrs_anvil/annotator.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Generator
 
 import yaml
-from ga4gh.vrs._internal.models import Allele  # noqa  F401 'Allele' private member
+from ga4gh.vrs import models as VRS
 from tqdm import tqdm
 
 import vrs_anvil
@@ -50,8 +50,8 @@ def _work_file_generator(manifest: Manifest) -> Generator[pathlib.Path, None, No
         yield work_file
 
 
-def _vcf_generator(manifest: Manifest) -> Generator[tuple, None, None]:
-    """Return a gnomad expression generator for each line in the vcf."""
+def _vcf_item_generator(manifest: Manifest) -> Generator[tuple, None, None]:
+    """Return a VCFItem for each line in the vcf."""
     total_lines = 0
     for work_file in tqdm(
         _work_file_generator(manifest),
@@ -110,7 +110,7 @@ def _vrs_generator(manifest: Manifest) -> Generator[dict, None, None]:
     c = 0
     for result in tlr.translate_from(
         generator=tqdm(
-            _vcf_generator(manifest),
+            _vcf_item_generator(manifest),
             total=manifest.estimated_vcf_lines,
             disable=manifest.disable_progress_bars,
         ),
@@ -123,7 +123,7 @@ def _vrs_generator(manifest: Manifest) -> Generator[dict, None, None]:
     )
 
 
-def vrs_ids(allele: Allele) -> list[str]:
+def vrs_ids(allele: VRS.Allele) -> list[str]:
     """Return a list of VRS ids from an allele."""
     return [allele.id]  # , allele.location.id, allele.location.sequence_id]
 
@@ -159,20 +159,18 @@ def annotate_all(
             if total_errors > max_errors:
                 break
         else:
-            allele = result.result
-            assert isinstance(
-                allele, Allele
-            ), f"result is not the expected Pydantic Model {type(allele)} {result.keys()}"
+            allele_id = result.result
+
             metrics[file_path][SUCCESSES] += 1
 
             # check metaKB cache, TODO - it would be nice if we had the metakb.study.id and added that to result_dict
-            if any([metakb_proxy.get(_) for _ in vrs_ids(allele)]):
-                _logger.info(f"VRS id {allele.id} found in metakb. {result}")
+            if any([metakb_proxy.get(_) for _ in allele_id]):
+                _logger.info(f"VRS id {allele_id} found in metakb. {result}")
 
-                # add vrs_id, allele_dict,actual evidence to this object as well (#3)
-                metrics[file_path][MATCHES][allele.id] = {
-                    PARAMETERS: {"fmt": result.fmt, "var": result.var},
-                    VRS_OBJECT: allele.model_dump(exclude_none=True),
+                # add vrs_id, allele_dict, actual evidence to this object as well (#3)
+                metrics[file_path][MATCHES][allele_id] = {
+                    "fmt": result.fmt,
+                    "var": result.var,
                 }
 
                 metrics[file_path][METAKB_HITS] += 1

--- a/vrs_anvil/translator.py
+++ b/vrs_anvil/translator.py
@@ -30,9 +30,9 @@ class WorkerThread(threading.Thread):
                     break  # Signal to exit the thread
 
                 self.busy = True
-                allele = self.translator.translate_from(fmt=item.fmt, var=item.var)
+                allele_id = self.translator.translate_from(fmt=item.fmt, var=item.var)
                 _ = item._asdict()
-                _["result"] = allele
+                _["result"] = allele_id
                 result = VCFItem(**_)
                 self.result_queue.put(PrioritizedItem(1, result))
 
@@ -90,9 +90,9 @@ def inline_translator(
     """A generator that runs the translation in a non-threaded fashion."""
     tlr = caching_allele_translator_factory(normalize=normalize)
     for item in generator:
-        allele = tlr.translate_from(fmt=item.fmt, var=item.var)
+        allele_id = tlr.translate_from(fmt=item.fmt, var=item.var)
         _ = item._asdict()
-        _["result"] = allele
+        _["result"] = allele_id
         yield VCFItem(**_)
 
 


### PR DESCRIPTION
Addresses #80. I think the idea feels right but the implementation might be a contention point, see below.

**Motivation**
- #80: Cache gets too large for analysts to use cache, especially for large datasets where they would get the most mileage out of our repo (caching/threading otherwise)
- This is pertinent in situations like...
  - GREGoR where we might processes many VCFs all corresponding to the same region
  - BMEG where we might have a overlap in variants between various VCFs and sources

**Design**
- Change the cache from storing the VRS object to the VRS ID
- Update tests to test the VRS ID as input rather than the entire object
- Metrics file instead of outputting the entire VRS objects just has the ID like so...
```yaml
total:
   ...
work/metakb-success-one-row.vcf:
  ...
  matches:
    ga4gh:VA.SOEVGpU16hxYQtJNeRyfq0V-B0rSOGK-:
      fmt: gnomad
      var: chr1-11796321-G-A
```
- 

**Testing**
- Able to locate a metakb result using `vrs_bulk annotate`
- Cache for 100k variants is 16.8 vs 109.2 MB (~6x smaller)
- Speed is still about the same (normalize=False: 2.4k while caching vs 4k using cache)

**Open Questions**
- `translate_from` now returns a ID instead of a VRS Allele object, which is now a different signature from the original `translate_from` in vrs_python. Is this a problem?
- If we want to get the entire VRS object, we either have to re-translate or get the entire object from metakb, which feels like work done twice. Is this a problem?
- How helpful is the cache to analysts if it only provides ~2x speedup?