### PR TITLE
chore: don't check protected fixtures into source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,9 @@ settings.json
 
 # workspace
 tmp/
+
+# GREGoR integration test fixtures
+# these could contain protected data and shouldn't be checked into source control
+tests/fixtures/gregor/phenotypes.tsv
+tests/fixtures/gregor/phenotypes.csv
+tests/fixtures/gregor/chr3_chrY_index.db


### PR DESCRIPTION
I figured this might be a good idea -- the GREGoR integration tests use some data that a developer has to provide themselves, so we might want to add those paths to the `.gitignore` file to prevent them from accidentally being committed