### PR TITLE
refactor: use __name__ for logger name

### DIFF
--- a/src/vrs_anvil/__init__.py
+++ b/src/vrs_anvil/__init__.py
@@ -18,7 +18,7 @@ import requests
 import yaml
 
 
-_logger = logging.getLogger("vrs_anvil")
+_logger = logging.getLogger(__name__)
 LOGGED_ALREADY = set()
 METAKB_API = "https://dev-search.cancervariants.org/api/v2"
 

--- a/src/vrs_anvil/annotator.py
+++ b/src/vrs_anvil/annotator.py
@@ -15,7 +15,7 @@ from vrs_anvil import Manifest, generate_gnomad_ids
 from vrs_anvil.collector import collect_manifest_urls
 from vrs_anvil.translator import Translator, VCFItem
 
-_logger = logging.getLogger("vrs_anvil.annotator")
+_logger = logging.getLogger(__name__)
 
 # enums for metrics
 # TODO: do this for keys across files like "parameters" but also "fmt" and "line"

--- a/src/vrs_anvil/cli.py
+++ b/src/vrs_anvil/cli.py
@@ -18,7 +18,7 @@ import pathlib
 # Set up logging
 log_format = "%(asctime)s %(threadName)s %(name)s [%(levelname)s] %(message)s"
 
-_logger = logging.getLogger("vrs_anvil.cli")
+_logger = logging.getLogger(__name__)
 
 
 @click.group(invoke_without_command=True)

--- a/src/vrs_anvil/translator.py
+++ b/src/vrs_anvil/translator.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 from vrs_anvil import caching_allele_translator_factory
 
-_logger = logging.getLogger("vrs_anvil.translator")
+_logger = logging.getLogger(__name__)
 
 
 class WorkerThread(threading.Thread):


### PR DESCRIPTION
small fix -- it's [generally recommended](https://docs.python.org/3/howto/logging.html#when-to-use-logging) to just use the dunder so that you don't have to change the value if you move modules around